### PR TITLE
Removed subdomain reference and added OIDC_BASE_URI example

### DIFF
--- a/1. Auth Flow/.env.sample
+++ b/1. Auth Flow/.env.sample
@@ -1,4 +1,4 @@
-SUBDOMAIN=
+OIDC_BASE_URI=https://your-onelogin-subdomain.onelogin.com
 OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
 OIDC_REDIRECT_URI=http://localhost:3000/oauth/callback

--- a/1. Auth Flow/routes/users.js
+++ b/1. Auth Flow/routes/users.js
@@ -20,7 +20,7 @@ router.get('/', function(req, res, next) {
 /* GET the profile of the current authenticated user */
 router.get('/profile', function(req, res, next) {
   request.get(
-    `https://${ process.env.SUBDOMAIN }.onelogin.com/oidc/2/me`,   
+    `https://${ process.env.OIDC_BASE_URI }/oidc/2/me`,   
     {
     'auth': {
       'bearer': req.session.accessToken


### PR DESCRIPTION
Remove the SUBDOMAIN env var which is no longer used.

Added OIDC_BASE_URI to env vars. This should be set to the base uri of a OneLogin account. 

e.g.`https://my-onelogin-account.onelogin.com`